### PR TITLE
Add allowed symbols and type to slot modifier list

### DIFF
--- a/grammars/clips.cson
+++ b/grammars/clips.cson
@@ -42,7 +42,7 @@ patterns: [
           # Slot modifier
           {
             comment: 'slot modifier'
-            begin: '(\\()[\\s\\t]*(allowed\\-values|default|default\\-dynamic)(?!-)\\b'
+            begin: '(\\()[\\s\\t]*(allowed\\-values|type|allowed\\-symbols|default|default\\-dynamic)(?!-)\\b'
             beginCaptures:
               '1':
                 name: 'support.function.clips'


### PR DESCRIPTION
Improve syntax coloration when using type or allowed-symbols in a slot modifier list.

`(slot name
    (type SYMBOL))`

`(slot sex
    (allowed-symbols male female))`