### PR TITLE
prefix 'not' was duplicated

### DIFF
--- a/snippets/clips.cson
+++ b/snippets/clips.cson
@@ -41,9 +41,6 @@
   not:
     prefix: 'not'
     body: 'not\n\t($1)\n'
-  not:
-    prefix: 'not'
-    body: 'not\n\t($1)\n'
   and:
     prefix: 'and'
     body: 'and\n\t($1)\n\t($2)\n'


### PR DESCRIPTION
When I opened Atom, I got this error in the path where I had saved this package.